### PR TITLE
Support AWS CodeBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Please have a look at the [ECS](ecs/) part for usage details.
 ### Kubernetes
 
 Please have a look at the [Kubernetes](kubernetes/) part for usage details.
+
+### CodeBuild
+
+Please have a look at the [CodeBuild](codebuild/) part for usage details.

--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -1,0 +1,49 @@
+# AWS CodeBuild
+
+For AWS CodeBuild projects, use the following script provided.
+The script will output all publicly hosted docker images found in the projects.
+
+The script will use your current AWS CLI credentials to find CodeBuild projects and return a list of image names.
+
+```
+$ ./detect-images.sh
+
+my-cb-project-1 toricls/everlasting-hey-yo:latest
+my-cb-project-2 toricls/everlasting-hey-yo:custom
+```
+
+The script works with existing `aws` command and your current AWS CLI credentials.
+If you would like to iterate over all configured AWS profiles then you can use a loop similar to the example below.
+
+```
+for prof in $(aws configure list-profiles); do
+  export AWS_PROFILE=$prof && ./detect-images.sh \
+    | sed "s/^/$prof /"
+done
+
+profile1 my-cb-project-1 toricls/everlasting-hey-yo:latest
+profile1 my-cb-project-2 toricls/everlasting-hey-yo:custom
+profile2 another-cb-project docker:dind
+```
+
+If you have multiple regions or AWS profiles with projects you can also use additional for loops to get containers from all your projects.
+
+```
+for prof in $(aws configure list-profiles); do
+  export AWS_PROFILE=$prof
+  for region in us-east-1 eu-west-1 us-west-2; do
+    export AWS_REGION=$region && ./detect-images.sh \
+    | sed "s/^/$prof $region /"
+  done
+done
+
+profileDev us-east-1 my-cb-project docker:dind
+profileStg us-east-1 another-cb-project docker:dind
+profileStg us-west-2 another-cb-project docker:dind
+profileProd us-east-1 another-cb-project docker:dind
+profileProd us-west-2 another-cb-project docker:dind
+```
+
+Note that at the current point we filter images based on detecting
+a FQDN in the first field of the image name except `docker.io`. This may not be a perfect
+matching strategy, but we hope it will work for the large majority of cases.

--- a/codebuild/detect-images.sh
+++ b/codebuild/detect-images.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -eu
+
+function listCodeBuildProjects() {
+    starting_token=$1
+
+    cmd="aws codebuild list-projects --sort-by NAME --sort-order ASCENDING --max-items 30 --output json --query={NextToken:NextToken,projects:projects[*]}"
+    if [[ "x$starting_token" = "x" ]]; then
+        output=$($cmd)
+    else
+        output=$($cmd --starting-token $starting_token)  
+    fi
+    echo $output
+}
+
+project_names=""
+next_token=""
+while [[ ! "x$next_token" = "xnull" ]]
+do
+    output=$(listCodeBuildProjects "$next_token")
+    next_token=$(echo $output | grep -Eo '"NextToken": [^,]*' | grep -Eo '[^ :]*$' | sed 's/"//g')
+    projects=$(echo $output | grep -Eo '"projects": \[.*\]' | sed 's/"projects": \[//g' | grep -Eo '"[^,]*"' | sed 's/"//g')
+    project_names="$projects $project_names"
+done
+
+if [[ -z "${project_names// }" ]]; then
+    exit 0
+fi
+
+for project in $project_names; do
+    images=$(aws codebuild batch-get-projects --names "$project" --query="projects[].environment | [?!(starts_with(image,'aws/codebuild/'))].image | sort(@) | join(' ', @)" --output text)
+    dhimages=()
+    for i in ${images[*]};
+    do
+        if ! echo $i | awk -F '[/:]' '{print $1}' | grep -q '\.' ; then
+            dhimages+=("$i")
+        elif echo $i | grep -q docker.io ; then
+            dhimages+=("$i")
+        fi
+    done
+
+    if [[ ! -z "${dhimages[@]+"${dhimages[@]}"}" ]]; then
+        for image in ${dhimages[*]}; do
+            echo "$project $image"
+        done
+    fi
+done


### PR DESCRIPTION
This PR adds support for AWS CodeBuild to find use of public container images in Docker Hub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
