### PR TITLE
modify kubectl jsonpath to include initcontainer images

### DIFF
--- a/kubernetes/detect-images.sh
+++ b/kubernetes/detect-images.sh
@@ -20,7 +20,7 @@ function detectForMachine() {
     # Note that the following is based on the command from the upstream docs, see:
     # https://kubernetes.io/docs/tasks/access-application-cluster/list-all-running-container-images/
     dhimages=()
-    allimages=$(kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s " " "\n" | sort -u)
+    allimages=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s " " "\n" | sort -u)
 
     for i in ${allimages[*]}
     do


### PR DESCRIPTION
*Issue #, if available:*

Description of changes: kubectl JSON path regex to include init containers as well. the current implementation only supports only running containers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
