### PR TITLE
making modifications based on shellcheck -S error

### DIFF
--- a/codebuild/detect-images.sh
+++ b/codebuild/detect-images.sh
@@ -39,7 +39,7 @@ for project in $project_names; do
         fi
     done
 
-    if [[ ! -z "${dhimages[@]+"${dhimages[@]}"}" ]]; then
+    if [[ ! -z "${dhimages[*]+"${dhimages[*]}"}" ]]; then
         for image in ${dhimages[*]}; do
             echo "$project $image"
         done

--- a/ecs/detect-images.sh
+++ b/ecs/detect-images.sh
@@ -67,7 +67,7 @@ for cluster in $clusters; do
         fi
     done
 
-    if [[ ! -z "${dhimages[@]+"${dhimages[@]}"}" ]]; then
+    if [[ ! -z "${dhimages[*]+"${dhimages[*]}"}" ]]; then
         for image in ${dhimages[*]}; do
             echo "$cluster $image"
         done


### PR DESCRIPTION
**NOTE:** I didn't test these changes on my machine because I didn't have something to run them against. So, before merging you might want to check and make sure everything still work. ( in theory it should )

*Description of changes:*
I modified the following scripts:
- codebuild/detect-images.sh ( line 42 )
- ecs/detect-images.sh ( line 70 )

so that they no longer used the `[@]` inside of if conditions, because based on a really cool tool called [shellcheck](https://github.com/koalaman/shellcheck/) it might cause errors: https://github.com/koalaman/shellcheck/wiki/SC2199

This was the command that I ran, with it's output:

```bash
$ shellcheck -S error */*.sh                       

In codebuild/detect-images.sh line 42:
    if [[ ! -z "${dhimages[@]+"${dhimages[@]}"}" ]]; then
               ^-- SC2199: Arrays implicitly concatenate in [[ ]]. Use a loop (or explicit * instead of @).


In ecs/detect-images.sh line 70:
    if [[ ! -z "${dhimages[@]+"${dhimages[@]}"}" ]]; then
               ^-- SC2199: Arrays implicitly concatenate in [[ ]]. Use a loop (or explicit * instead of @).
```

I only did the error severity of shellcheck for this PR, so that it was focused and it could be a way to start the conversation about using it in the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
