### PR TITLE
Update detect-images.sh

### DIFF
--- a/source/detect-images.sh
+++ b/source/detect-images.sh
@@ -7,8 +7,8 @@ function detect() {
 
 tdir=$(dirname $TARGET_DIR)/$(basename $TARGET_DIR)
 
-# iterate over all Dockerfiles and list images:
-filelist=($(find ${tdir} -type f -name Dockerfile\*))
+# iterate over all Dockerfiles / Containerfiles and list images:
+filelist=($(find ${tdir} -type f -name Dockerfile\* -o -name Containerfile\*))
 
 # capture the public registry list
 registrylist=$(cat public_registries.conf)


### PR DESCRIPTION
*Issue #, if available:*

Current implementation only looks for Dockerfiles when Containerfile is an equivalent alternative and more commonly found in podman based deployments.

*Description of changes:*

Also find Containerfiles, which are more commonly used in podman deployments

https://github.com/containers/common/blob/f8ddf58e269b744367c0b5efc1be8da03e075568/docs/Containerfile.5.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
